### PR TITLE
Implementing resilient client websocket for CryptoCompare

### DIFF
--- a/src/Simulator/CryptoCompareClient/CryptoCompareClient.csproj
+++ b/src/Simulator/CryptoCompareClient/CryptoCompareClient.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trakx.CryptoCompare.ApiClient\Trakx.CryptoCompare.ApiClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Simulator/CryptoCompareClient/Program.cs
+++ b/src/Simulator/CryptoCompareClient/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Trakx.CryptoCompare.ApiClient;
+using Trakx.CryptoCompare.ApiClient.WebSocket;
+
+namespace CryptoCompareWebSocketClient
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var webSocketClient = new ResilientClientWebsocket();
+            var config = new CryptoCompareApiConfiguration
+            {
+                WebSocketBaseUrl = "ws://localhost:5000",
+                ApiKey = "abcdefg"
+            };
+            var streamer = new WebSocketStreamer();
+            var cryptoClient = new Trakx.CryptoCompare.ApiClient.WebSocket.CryptoCompareWebSocketClient(webSocketClient, 
+                Options.Create(config), streamer);
+            using var sub = cryptoClient.WebSocketStreamer.HeartBeatStream.Subscribe(res =>
+            {
+                Console.WriteLine($"CryptoCompare Server has triggered HeartBeat event - {res.Message} -- {res.TimeMs}");
+            });
+            await cryptoClient.Connect();
+            Console.ReadKey();
+        }
+    }
+}

--- a/src/Simulator/CryptoCompareServer/CryptoCompareServer.csproj
+++ b/src/Simulator/CryptoCompareServer/CryptoCompareServer.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <AssemblyName>CryptoCompareServer</AssemblyName>
+    <RootNamespace>CryptoCompareServer</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/src/Simulator/CryptoCompareServer/Middleware/WebSocketServerMiddleware.cs
+++ b/src/Simulator/CryptoCompareServer/Middleware/WebSocketServerMiddleware.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace CryptoCompareServer.Middleware
+{
+    public class CryptoCompareServerMiddleware
+    {
+
+        private readonly RequestDelegate _next;
+
+        public CryptoCompareServerMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (context.WebSockets.IsWebSocketRequest)
+            {
+                WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
+
+                Console.WriteLine("WebSocket Connected");
+
+                await ReceiveAndSend(webSocket, (result, buffer) =>
+                {
+                    if (result.MessageType == WebSocketMessageType.Text)
+                    {
+                        Console.WriteLine($"Receive->Text");
+                        Console.WriteLine($"Message: {Encoding.UTF8.GetString(buffer, 0, result.Count)}");
+                        return;
+                    }
+                    else if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        Console.WriteLine($"Receive->Close");
+
+                        return;
+                    }
+                });
+            }
+            else
+            {
+                Console.WriteLine("Hello from 2nd Request Delegate - No WebSocket");
+                await _next(context);
+            }
+        }
+
+        private async Task ReceiveAndSend(WebSocket socket, Action<WebSocketReceiveResult, byte[]> handleMessage)
+        {
+            while (socket.State == WebSocketState.Open)
+            {
+                var data = $"{{ \"TYPE\": \"999\", \"MESSAGE\": \"AAA\", \"TIMEMS\": {DateTime.Now.Second} }}";
+                var buffer = Encoding.UTF8.GetBytes(data);
+                await socket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
+                await Task.Delay(TimeSpan.FromSeconds(3));
+            }
+        }
+    }
+}

--- a/src/Simulator/CryptoCompareServer/Middleware/WebSocketServerMiddlewareExtensions.cs
+++ b/src/Simulator/CryptoCompareServer/Middleware/WebSocketServerMiddlewareExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace CryptoCompareServer.Middleware
+{
+    public static class CryptoCompareServerMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseCryptoCompareServer(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<CryptoCompareServerMiddleware>();
+        }
+    }
+}

--- a/src/Simulator/CryptoCompareServer/Program.cs
+++ b/src/Simulator/CryptoCompareServer/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace CryptoCompareServer
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/Simulator/CryptoCompareServer/Startup.cs
+++ b/src/Simulator/CryptoCompareServer/Startup.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using CryptoCompareServer.Middleware;
+
+namespace CryptoCompareServer
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseWebSockets();
+            app.UseCryptoCompareServer();
+        }
+
+    }
+}

--- a/src/Simulator/CryptoCompareServer/appsettings.Development.json
+++ b/src/Simulator/CryptoCompareServer/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/Simulator/CryptoCompareServer/appsettings.json
+++ b/src/Simulator/CryptoCompareServer/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Trakx.CryptoCompare.ApiClient.Tests/Integration/WebSocketClientIntegrationTests.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Tests/Integration/WebSocketClientIntegrationTests.cs
@@ -27,11 +27,11 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration
             _output = output;
             var streamer = new WebSocketStreamer();
             var apiDetailsProvider = new CryptoCompareApiConfiguration {ApiKey = new Secrets().ApiKey};
-            var clientWebSocket = new WrappedClientWebsocket();
+            var clientWebSocket = new ResilientClientWebsocket();
             _client = new CryptoCompareWebSocketClient(clientWebSocket, Options.Create(apiDetailsProvider), streamer);
         }
 
-        [Fact]
+        [Fact(Timeout = 10000)]
 #pragma warning disable S2699 // Tests should include assertions
         public async Task WebSocketClient_should_receive_Trade_updates()
 #pragma warning restore S2699 // Tests should include assertions
@@ -40,7 +40,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration
             await RunTestForSubscriptionType<Trade>(btcUsdSubscription);
         }
 
-        [Fact]
+        [Fact(Timeout = 10000)]
 #pragma warning disable S2699 // Tests should include assertions
         public async Task WebSocketClient_should_receive_Ticker_updates()
 #pragma warning restore S2699 // Tests should include assertions
@@ -49,7 +49,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration
             await RunTestForSubscriptionType<Ticker>(btcUsdSubscription);
         }
 
-        [Fact]
+        [Fact(Timeout = 10000)]
 #pragma warning disable S2699 // Tests should include assertions
         public async Task WebSocketClient_should_receive_AggregateIndice_updates()
 #pragma warning restore S2699 // Tests should include assertions
@@ -58,7 +58,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration
             await RunTestForSubscriptionType<AggregateIndex>(btcUsdSubscription);
         }
 
-        [Fact]
+        [Fact(Timeout = 10000)]
 #pragma warning disable S2699 // Tests should include assertions
         public async Task WebSocketClient_should_receive_Ohlc_updates()
 #pragma warning restore S2699 // Tests should include assertions
@@ -85,7 +85,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration
 
 
             await _client.AddSubscriptions(subscription).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(500));
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
 
             messagesReceived.Count.Should().BeGreaterOrEqualTo(3);
 
@@ -94,7 +94,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration
             messagesReceived.OfType<LoadComplete>().Count().Should().BeGreaterOrEqualTo(1);
             
             await _client.RemoveSubscriptions(subscription).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(500));
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
 
             messagesReceived.Count.Should().BeGreaterOrEqualTo(5);
             messagesReceived.OfType<SubscribeComplete>().Count().Should().BeGreaterOrEqualTo(1);

--- a/src/Trakx.CryptoCompare.ApiClient.sln
+++ b/src/Trakx.CryptoCompare.ApiClient.sln
@@ -35,6 +35,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Trakx.CryptoCompare.ApiClie
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Trakx.CryptoCompare.ApiClient.Tests", "Trakx.CryptoCompare.ApiClient.Tests\Trakx.CryptoCompare.ApiClient.Tests.csproj", "{D370556E-337B-4021-B954-71CE9AD1BCF8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Simulator", "Simulator", "{33BD2D53-BDD9-4DBD-8ACB-FF6A0BCB9390}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CryptoCompareServer", "Simulator\CryptoCompareServer\CryptoCompareServer.csproj", "{FCADE019-000C-49E0-8BFE-7ADFAD41576B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CryptoCompareClient", "Simulator\CryptoCompareClient\CryptoCompareClient.csproj", "{34274EA6-C85C-4E53-90BF-18B670C7D5F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +55,14 @@ Global
 		{D370556E-337B-4021-B954-71CE9AD1BCF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D370556E-337B-4021-B954-71CE9AD1BCF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D370556E-337B-4021-B954-71CE9AD1BCF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCADE019-000C-49E0-8BFE-7ADFAD41576B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCADE019-000C-49E0-8BFE-7ADFAD41576B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCADE019-000C-49E0-8BFE-7ADFAD41576B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCADE019-000C-49E0-8BFE-7ADFAD41576B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34274EA6-C85C-4E53-90BF-18B670C7D5F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34274EA6-C85C-4E53-90BF-18B670C7D5F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34274EA6-C85C-4E53-90BF-18B670C7D5F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34274EA6-C85C-4E53-90BF-18B670C7D5F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -56,6 +70,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{6016A446-EAD5-451B-B8C0-EC13794036FB} = {B4B8ECDB-63A4-431A-8313-2D90142033C1}
 		{C1DFC2BD-A633-4692-9196-EBF451A87AE0} = {6016A446-EAD5-451B-B8C0-EC13794036FB}
+		{FCADE019-000C-49E0-8BFE-7ADFAD41576B} = {33BD2D53-BDD9-4DBD-8ACB-FF6A0BCB9390}
+		{34274EA6-C85C-4E53-90BF-18B670C7D5F2} = {33BD2D53-BDD9-4DBD-8ACB-FF6A0BCB9390}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3F131DCD-33E4-47BA-8829-65E49F744112}

--- a/src/Trakx.CryptoCompare.ApiClient/ServiceConfiguration.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/ServiceConfiguration.cs
@@ -31,10 +31,10 @@ namespace Trakx.CryptoCompare.ApiClient
         private static void AddCommonDependencies(IServiceCollection services)
         {
             services.AddSingleton<ICryptoCompareClient, CryptoCompareClient>();
-            services.AddTransient<IClientWebsocket, WrappedClientWebsocket>();
+            services.AddTransient<IClientWebsocket, ResilientClientWebsocket>();
             services.AddTransient<IWebSocketStreamer, WebSocketStreamer>();
             services.AddSingleton<ICryptoCompareWebSocketClient, CryptoCompareWebSocketClient>();
-            services.AddSingleton<WrappedClientWebsocket>();
+            services.AddSingleton<ResilientClientWebsocket>();
         }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/WebSocket/IClientWebsocket.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/WebSocket/IClientWebsocket.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.WebSockets;
 using System.Reflection;
-using System.Resources;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
@@ -101,6 +100,7 @@ namespace Trakx.CryptoCompare.ApiClient.WebSocket
           WebSocketMessageType messageType,
           bool endOfMessage,
           CancellationToken cancellationToken);
+
     }
 
     public sealed class ResilientClientWebsocket : IClientWebsocket
@@ -220,7 +220,8 @@ namespace Trakx.CryptoCompare.ApiClient.WebSocket
         private async Task TryReconnect()
         {
             Logger.Information($"Attempting to reconnect to '{_uri}'...");
-            try {
+            try
+            {
                 _client.Dispose();
                 _client = new ClientWebSocket();
                 await _client.ConnectAsync(_uri, _cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
- Implement ResilientClientWebsocket to handle downtimes in the CryptoCompare Websocket Server.


HOW TO TEST IT:

1)  Run "dotnet run" via command line inside the folder "cryptocompare-api-client\src\Simulator\CryptoCompareServer" to start publishing responses from CryptoCompare Mocked Server;
2) Run the project "Simulator/CryptoCompareClient" to start receiving messages from CryptoCompare Mocked Server.
3) Press "Control + C" in the command line to stop "CryptoCompareServer";
4) Notice the client will continue working as expected but not receiving messages anymore;
5)  Now, run again "dotnet run" via command line  inside the folder "cryptocompare-api-client\src\Simulator\CryptoCompareServer" - to restart CryptoCompare Mocked server;
6) Notice CryptoCompareClient will start to receive websocket messages again; thanks to ResilientClientWebsocket implementation.


ROOM TO IMPROVE:

See below the list of items that I don't seem to look so pretty and could be improved if time allows:

1) The use of "while (true)" inside the methods "ResilientClientWebsocket.ReceiveAsync(..)". Perhaps, I should use Observable instead or Polly.Retry.

2) I was unable to reproduce websocket disconnects via unit tests. The reason is because "System.Net.WebSockets.ClientWebSocket" does not implement any interface that could be mocked via NSubstitute. So, I believe I am with hands tied to simulate websocket server downtime.

3) Ideally, the try catch for "ResilientClientWebsocket.ReceiveAsync(..)" should only handles WebSocketExceptions. However, after the first and second WebSocketException exceptions thrown, client starts throwing NullReference exceptions. So, I had to include this exception type in the list of retries as well. (not sure if it is something I am not seeing right).