### PR TITLE
`AddInternalAsync` refactor and explicit `RemoveAsync`

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
 

--- a/.github/workflows/publish.nuget.yml
+++ b/.github/workflows/publish.nuget.yml
@@ -43,12 +43,12 @@ jobs:
 
       - name: Bump version
         id: bumpVersion
-        uses: trakx/bump-version-action/get-tag@v9.1.1
+        uses: trakx/bump-version-action/get-tag@v10.0.14
         with:
           semverIncrementLevel: ${{github.event.inputs.semverIncrementLevel}}
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Push version tag
         id: pushTag
-        uses: trakx/bump-version-action/push-tag@v9.1.1
+        uses: trakx/bump-version-action/push-tag@v10.0.14
         with:
           tag: v${{steps.bumpVersion.outputs.fullVersion}}
           githubToken: ${{secrets.GITHUB_TOKEN}}

--- a/src/Trakx.CryptoCompare.ApiClient.Tests/Trakx.CryptoCompare.ApiClient.Tests.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Tests/Trakx.CryptoCompare.ApiClient.Tests.csproj
@@ -16,15 +16,15 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1">
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.2.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.2.0" />
+        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.2.2" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
@@ -33,8 +33,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference
-            Include="..\Trakx.CryptoCompare.ApiClient\Trakx.CryptoCompare.ApiClient.csproj" />
+        <ProjectReference Include="..\Trakx.CryptoCompare.ApiClient\Trakx.CryptoCompare.ApiClient.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Trakx.CryptoCompare.ApiClient.Tests/Trakx.CryptoCompare.ApiClient.Tests.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Tests/Trakx.CryptoCompare.ApiClient.Tests.csproj
@@ -8,11 +8,11 @@
     <Import Project="../Common.Projects.props" />
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Trakx.CryptoCompare.ApiClient.Websocket.Tests.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Trakx.CryptoCompare.ApiClient.Websocket.Tests.csproj
@@ -18,7 +18,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1">
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.2.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -28,8 +28,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Trakx.CryptoCompare.ApiClient.Websocket.Tests.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Trakx.CryptoCompare.ApiClient.Websocket.Tests.csproj
@@ -10,11 +10,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="Trakx.Websockets.Testing" Version="1.0.0" />
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Unit/CryptoCompareWebsocketHandlerTests.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Unit/CryptoCompareWebsocketHandlerTests.cs
@@ -1,12 +1,11 @@
-using FluentAssertions;
-using Microsoft.Extensions.Options;
-using NSubstitute;
 using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
 using Trakx.CryptoCompare.ApiClient.Websocket.Model;
 using Trakx.Websocket.Interfaces;
 using Trakx.Websocket.Model;
@@ -20,10 +19,15 @@ public class CryptoCompareWebsocketHandlerTests
 {
     private readonly TestWebsocketClient _testClient;
     private readonly CryptoCompareWebsocketHandler _websocketHandler;
+    private readonly TopicSubscription _topicSub;
+    private readonly TopicSubscription _removeSub;
+
+    private int SubscriptionCount => _websocketHandler.CurrentSubscriptions.Count;
 
     public CryptoCompareWebsocketHandlerTests()
     {
         _testClient = Substitute.ForPartsOf<TestWebsocketClient>();
+
         var fakeConfiguration = new WebsocketConfiguration
         {
             BufferSize = 4092,
@@ -33,35 +37,70 @@ public class CryptoCompareWebsocketHandlerTests
         var fakeWebsocketFactory = Substitute.For<IClientWebsocketFactory>();
         fakeWebsocketFactory.CreateNewWebSocket(Arg.Any<Uri>(), Arg.Any<Action<WebsocketClient>>())
             .Returns(_testClient);
+
         var fakeFinexConfig = new CryptoCompareApiConfiguration()
         {
             WebSocketBaseUrl = "https://www.google.com"
         };
 
         _websocketHandler = new CryptoCompareWebsocketHandler(fakeConfiguration, fakeFinexConfig, fakeWebsocketFactory);
+
+        _topicSub = SetupTopicSubscription(SubscribeActions.SubAdd);
+        _removeSub = SetupTopicSubscription(SubscribeActions.SubRemove);
     }
 
     [Fact]
-    public async Task AddAsync_should_remove_subscription_on_sub_remove()
+    public async Task AddAsync_sends_message_to_client()
     {
-        var topicSub = CryptoCompareSubscriptionFactory.GetTopicSubscription(SubscribeActions.SubAdd,
-            CryptoCompareSubscriptionFactory.GetFullTopTierVolumeSubscriptionStr("test"));
-        var removeSub = CryptoCompareSubscriptionFactory.GetTopicSubscription(SubscribeActions.SubRemove,
-            CryptoCompareSubscriptionFactory.GetFullTopTierVolumeSubscriptionStr("test"));
-        await _websocketHandler.AddAsync(topicSub);
-        _websocketHandler.CurrentSubscriptions.Count.Should().Be(1);
-        await _websocketHandler.AddAsync(removeSub);
-        _websocketHandler.CurrentSubscriptions.Count.Should().Be(0);
+        await _websocketHandler.AddAsync(_topicSub);
+        _testClient.Received(1).Send(_topicSub.Topic);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_sends_message_to_client()
+    {
+        // this call is needed to "open" the channel
+        await _websocketHandler.AddAsync(_topicSub);
+
+        await _websocketHandler.RemoveAsync(_removeSub);
+
+        _testClient.Received(1).Send(_removeSub.Topic);
+    }
+
+    [Fact]
+    public async Task AddAsync_removes_subscription_on_sub_remove()
+    {
+        await _websocketHandler.AddAsync(_topicSub);
+        SubscriptionCount.Should().Be(1);
+
+        await _websocketHandler.AddAsync(_removeSub);
+        SubscriptionCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_only_removes_subscription_with_valid_topic()
+    {
+        await _websocketHandler.AddAsync(_topicSub);
+        SubscriptionCount.Should().Be(1);
+
+        // no changes because it doesn't have the SubRemove action
+        await _websocketHandler.RemoveAsync(_topicSub);
+        SubscriptionCount.Should().Be(1);
+
+        await _websocketHandler.RemoveAsync(_removeSub);
+        SubscriptionCount.Should().Be(0);
+
+        // only 2 message should have been sent, the first Add and the valid Remove
+        _testClient.Received(1).Send(_topicSub.Topic);
+        _testClient.Received(1).Send(_removeSub.Topic);
     }
 
     [Fact]
     public async Task IncomingMessage_should_map_to_correct_observer()
     {
-        var topicSub = CryptoCompareSubscriptionFactory.GetTopicSubscription(SubscribeActions.SubAdd,
-            CryptoCompareSubscriptionFactory.GetFullTopTierVolumeSubscriptionStr("test"));
-        await _websocketHandler.AddAsync(topicSub);
+        await _websocketHandler.AddAsync(_topicSub);
 
-        var topicMessageTask = _websocketHandler.GetTopicMessageStream<FullVolume>(topicSub.Topic)
+        var topicMessageTask = _websocketHandler.GetTopicMessageStream<FullVolume>(_topicSub.Topic)
             .Buffer(TimeSpan.FromSeconds(5), 1)
             .Select(t => t.FirstOrDefault())
             .FirstOrDefaultAsync()
@@ -74,5 +113,11 @@ public class CryptoCompareWebsocketHandlerTests
         topicMessage!.Type.Should().Be(fullVolumeMsg.Type);
         topicMessage!.Symbol.Should().Be(fullVolumeMsg.Symbol);
         topicMessage!.Volume.Should().Be(fullVolumeMsg.Volume);
+    }
+
+    private static TopicSubscription SetupTopicSubscription(SubscribeActions action)
+    {
+        var subscriptionString = CryptoCompareSubscriptionFactory.GetFullTopTierVolumeSubscriptionStr("test");
+        return CryptoCompareSubscriptionFactory.GetTopicSubscription(action, subscriptionString);
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Unit/CryptoCompareWebsocketHandlerTests.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Unit/CryptoCompareWebsocketHandlerTests.cs
@@ -17,6 +17,8 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Tests.Unit;
 
 public class CryptoCompareWebsocketHandlerTests
 {
+    private const string TestSymbol = "btc";
+
     private readonly TestWebsocketClient _testClient;
     private readonly CryptoCompareWebsocketHandler _websocketHandler;
     private readonly TopicSubscription _topicSub;
@@ -105,7 +107,7 @@ public class CryptoCompareWebsocketHandlerTests
             .Select(t => t.FirstOrDefault())
             .FirstOrDefaultAsync()
             .ToTask();
-        var fullVolumeMsg = new FullVolume { Type = "11", Volume = 1, Symbol = "BTC" };
+        var fullVolumeMsg = new FullVolume { Type = "11", Volume = 1, Symbol = TestSymbol };
         var fakeMsg = JsonSerializer.Serialize(fullVolumeMsg);
         _testClient.StreamFakeMessage(ResponseMessage.TextMessage(fakeMsg));
 
@@ -117,7 +119,7 @@ public class CryptoCompareWebsocketHandlerTests
 
     private static TopicSubscription SetupTopicSubscription(SubscribeActions action)
     {
-        var subscriptionString = CryptoCompareSubscriptionFactory.GetFullTopTierVolumeSubscriptionStr("test");
+        var subscriptionString = CryptoCompareSubscriptionFactory.GetFullTopTierVolumeSubscriptionStr(TestSymbol);
         return CryptoCompareSubscriptionFactory.GetTopicSubscription(action, subscriptionString);
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/CryptoCompareWebsocketHandler.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/CryptoCompareWebsocketHandler.cs
@@ -77,9 +77,9 @@ public class CryptoCompareWebsocketHandler : ClientWebsocketRedirectHandlerBase<
         if (payload == null) return false;
         if (payload.Action != SubscribeActions.SubRemove) return false;
 
-        foreach (var item in payload.Subs)
+        foreach (var payloadSub in payload.Subs)
         {
-            var toRemoveSubs = Subscriptions.Where(t => t.Topic.ContainsIgnoreCase(item)).ToList();
+            var toRemoveSubs = Subscriptions.Where(t => t.Topic.ContainsIgnoreCase(payloadSub)).ToList();
             foreach (var unwanted in toRemoveSubs)
             {
                 Subscriptions.Remove(unwanted);
@@ -92,9 +92,16 @@ public class CryptoCompareWebsocketHandler : ClientWebsocketRedirectHandlerBase<
         return true;
     }
 
+    /// <summary>
+    /// The <see cref="TopicSubscription.Topic"/> for <see cref="CryptoCompareWebsocketHandler"/>
+    /// has a payload of type <see cref="CryptoCompareSubscription"/>.
+    /// This method checks if the <see cref="CryptoCompareSubscription.Action"/> in the payload is <see cref="SubscribeActions.SubRemove"/>.
+    /// It's a fast string-based check, using the string representation of the enum.
+    /// The slower alternative would be parsing the JSON payload.
+    /// </summary>
     private static bool HasRemoveAction(TopicSubscription subscription)
     {
-        var remove = SubscribeActions.SubRemove.ToString();
-        return subscription.Topic.ContainsIgnoreCase(remove);
+        var subRemoveAsString = SubscribeActions.SubRemove.ToString();
+        return subscription.Topic.ContainsIgnoreCase(subRemoveAsString);
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/ICryptoCompareWebsocketHandler.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/ICryptoCompareWebsocketHandler.cs
@@ -1,8 +1,13 @@
-﻿using Trakx.CryptoCompare.ApiClient.Websocket.Model;
+﻿using System.Threading.Tasks;
+using Trakx.CryptoCompare.ApiClient.Websocket.Model;
 using Trakx.Websocket.Interfaces;
+using Trakx.Websocket.Model;
 
 namespace Trakx.CryptoCompare.ApiClient.Websocket;
 
 public interface ICryptoCompareWebsocketHandler : IClientWebsocketRedirectHandler<InboundMessageBase>
 {
+    /// <summary>Removes the specified session subscription.</summary>
+    /// <param name="subscription">The subscription.</param>
+    Task<bool> RemoveAsync(TopicSubscription subscription);
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Trakx.CryptoCompare.ApiClient.Websocket.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Trakx.CryptoCompare.ApiClient.Websocket.csproj
@@ -8,7 +8,7 @@
 	<Import Project="../Packable.Projects.props" />
 
 	<ItemGroup>
-		<PackageReference Include="Trakx.Common" Version="0.2.0" />
+		<PackageReference Include="Trakx.Common" Version="0.2.2" />
 		<PackageReference Include="Trakx.Websocket" Version="1.0.0" />
 	</ItemGroup>
 

--- a/src/Trakx.CryptoCompare.ApiClient/Trakx.CryptoCompare.ApiClient.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient/Trakx.CryptoCompare.ApiClient.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="Trakx.Common" Version="0.2.0" />
+    <PackageReference Include="Trakx.Common" Version="0.2.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The detection of trying to `SubRemove` subcriptions when calling `AddInternalAsync` was difficult to understand due to its use of `JsonDocument.Parse(subscription.Topic)`.

This PR introduces a strongly-typed deserialization of the topic, which allows us to work on the array of subs with clean code.

New `RemoveAsync(TopicSubscription subscription)` method added to `ICryptoCompareWebsocketHandler`.
There's one from the base interface in `websockets` which takes an `IList` of subscriptions, but doesn't do what we need in `market-data`.

Also bumped some nuget/actions versions.