### PR TITLE
Nuget bumps, fix IDE warnings and messages, nullable properties

### DIFF
--- a/src/Trakx.CryptoCompare.ApiClient.Tests/Integration/Rest/Clients/PriceClientTests.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Tests/Integration/Rest/Clients/PriceClientTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
@@ -38,7 +40,8 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration.Rest.Clients
             Assert.NotNull(result);
         }
 
-        [Fact] public async Task CanCallWithLargeNumberOfFSymbols()
+        [Fact]
+        public async Task CanCallWithLargeNumberOfFSymbols()
         {
             var symbols = new[]
             {
@@ -50,8 +53,13 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Integration.Rest.Clients
                 "srm", "cake", "luna"
             };
             var result = await CryptoCompareClient.Prices.MultipleSymbolsPriceAsync(symbols, new[] { "USD", "EUR" });
-            result.Count.Should().Be(symbols.Length);
-            Assert.NotNull(result);
+
+            result.Should().NotBeEmpty();
+
+            var missingKeys = symbols.Except(result.Keys, StringComparer.OrdinalIgnoreCase).Order().ToList();
+
+            var maximumMissingAllowed = symbols.Length * 10 / 100; // 10% missing
+            missingKeys.Count.Should().BeLessThanOrEqualTo(maximumMissingAllowed);
         }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Tests/Trakx.CryptoCompare.ApiClient.Tests.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Tests/Trakx.CryptoCompare.ApiClient.Tests.csproj
@@ -16,17 +16,17 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.2.1">
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-        <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.2.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.5.1" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Trakx.CryptoCompare.ApiClient.Tests/Unit/Rest/Helpers/CheckTest.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Tests/Unit/Rest/Helpers/CheckTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions;
 using Trakx.CryptoCompare.ApiClient.Rest.Helpers;
 using Xunit;
 
@@ -6,7 +7,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Unit.Rest.Helpers
 {
     public class CheckTest
     {
-        public static string Blah = nameof(Blah);
+        internal const string Blah = nameof(Blah);
 
         /// <summary>
         /// NotNullOrWhiteSpace should not throw ArgumentNullException when string is not null.
@@ -27,7 +28,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Unit.Rest.Helpers
         public void NotNullOrWhiteSpaceShouldThrowArgumentNullExceptionWhenStringIsNullOrEmptyOrWhitespace(string value)
         {
             var exception = Assert.Throws<ArgumentNullException>(() => Check.NotNullOrWhiteSpace(value, Blah));
-            Assert.Equal(exception.ParamName, Blah);
+            exception.ParamName.Should().Be(Blah);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Unit.Rest.Helpers
         public void NotNullShouldThrowArgumentNullExceptionWhenObjectIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(() => Check.NotNull<int?>(null, Blah));
-            Assert.Equal(exception.ParamName, Blah);
+            exception.ParamName.Should().Be(Blah);
         }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Tests/Unit/ServiceConfigurationTests.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Tests/Unit/ServiceConfigurationTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Trakx.CryptoCompare.ApiClient.Tests.Unit
@@ -13,7 +14,10 @@ namespace Trakx.CryptoCompare.ApiClient.Tests.Unit
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddCryptoCompareClient(configuration);
             serviceCollection.AddLogging();
-            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var action = () => _ = serviceCollection.BuildServiceProvider();
+
+            action.Should().NotThrow();
         }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Integration/CryptoCompareWebsocketHandlerTests.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Integration/CryptoCompareWebsocketHandlerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
@@ -40,12 +39,6 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Tests.Integration
             return serviceCollection.BuildServiceProvider();
         }
 
-        public void Dispose()
-        {
-            _serviceScope.Dispose();
-        }
-
-
         private async Task<T> GetResult<T>(string subStr, int bufferSeconds = 10)
             where T : InboundMessageBase
         {
@@ -66,10 +59,9 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Tests.Integration
         public async Task Should_be_able_to_get_full_top_tier_volume_subscriptions()
         {
             var subscriptionString = CryptoCompareSubscriptionFactory.GetFullTopTierVolumeSubscriptionStr("btc");
-            var result = await GetResult<TopTierFullVolume>(subscriptionString).ConfigureAwait(false);
+            var result = await GetResult<TopTierFullVolume>(subscriptionString);
             result!.Symbol.Should().Be("BTC");
-            decimal.TryParse(result.Volume, CultureInfo.InvariantCulture, out decimal volume);
-            volume.Should().BeGreaterThan(0);
+            result.Volume.Should().BeGreaterThan(0);
         }
 
         [Fact]
@@ -87,11 +79,35 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Tests.Integration
         public async Task Should_be_able_to_get_ohlcc_candles()
         {
             var subscriptionString = CryptoCompareSubscriptionFactory.GetOHLCCandlesSubscriptionStr("Binance", "btc", "usdt", "m");
-            var result = await GetResult<Ohlc>(subscriptionString).ConfigureAwait(false);
+            var result = await GetResult<Ohlc>(subscriptionString);
             result!.Open.Should().BeGreaterThan(0);
             result!.LastTimeStamp.Should().BeGreaterThan(0);
             result!.Market.Should().NotBeNull();
             result.Close.Should().BeGreaterThan(0);
         }
+
+        #region IDisposable
+
+        private bool _wasDisposed;
+
+        protected virtual bool Dispose(bool disposing)
+        {
+            if (_wasDisposed) return false;
+            if (disposing)
+            {
+                _serviceScope.Dispose();
+            }
+
+            _wasDisposed = true;
+            return true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Trakx.CryptoCompare.ApiClient.Websocket.Tests.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket.Tests/Trakx.CryptoCompare.ApiClient.Websocket.Tests.csproj
@@ -18,18 +18,18 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.2.1">
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.2.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.5.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Extensions/AddCryptoCompareWebsocketsExtensions.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Extensions/AddCryptoCompareWebsocketsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Trakx.Common.Configuration;
 using Trakx.Websocket;
 using Trakx.Websocket.Interfaces;
 using Trakx.Websocket.Model;
@@ -8,7 +9,10 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Extensions;
 
 public static class AddCryptoCompareWebsocketsExtensions
 {
-    public static void AddCryptoCompareWebsockets(this IServiceCollection services, CryptoCompareApiConfiguration apiConfiguration, WebsocketConfiguration webSocketConfiguration)
+    public static void AddCryptoCompareWebsockets(
+        this IServiceCollection services,
+        CryptoCompareApiConfiguration apiConfiguration,
+        WebsocketConfiguration webSocketConfiguration)
     {
         services.AddSingleton<ICryptoCompareWebsocketHandler, CryptoCompareWebsocketHandler>();
         services.AddSingleton<IClientWebsocketFactory, ClientWebsocketFactory>();
@@ -18,10 +22,8 @@ public static class AddCryptoCompareWebsocketsExtensions
 
     public static void AddCryptoCompareWebsockets(this IServiceCollection services, IConfiguration config)
     {
-        var apiConfiguration = config.GetSection(nameof(CryptoCompareApiConfiguration))
-            .Get<CryptoCompareApiConfiguration>();
-        var webSocketConfig = config.GetSection(nameof(WebsocketConfiguration)).Get<WebsocketConfiguration>();
-
+        var apiConfiguration = config.GetConfiguration<CryptoCompareApiConfiguration>();
+        var webSocketConfig = config.GetConfiguration<WebsocketConfiguration>();
         AddCryptoCompareWebsockets(services, apiConfiguration, webSocketConfig);
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/HeartBeat.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/HeartBeat.cs
@@ -4,6 +4,6 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Model;
 
 public class HeartBeat : InboundMessageBase
 {
-    [JsonPropertyName("MESSAGE")] public string Message { get; set; }
-    [JsonPropertyName("TIMEMS")] public ulong TimeMs { get; set; }
+    [JsonPropertyName("MESSAGE")] public string? Message { get; set; }
+    [JsonPropertyName("TIMEMS")] public ulong? TimeMs { get; set; }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/InboundMessageBase.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/InboundMessageBase.cs
@@ -4,5 +4,5 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Model;
 
 public class InboundMessageBase
 {
-    [JsonPropertyName("TYPE")] public string Type { get; set; }
+    [JsonPropertyName("TYPE")] public string? Type { get; set; }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/Ohlc.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/Ohlc.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json.Serialization;
-using Trakx.Common.Serialization.Converters;
+using Trakx.Common.Serialization.Comparers;
 
 namespace Trakx.CryptoCompare.ApiClient.Websocket.Model;
 

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/Ticker.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/Ticker.cs
@@ -1,14 +1,13 @@
 ﻿using System.Text.Json.Serialization;
-using Trakx.Common.Serialization.Converters;
+using Trakx.Common.Serialization.Comparers;
 
 namespace Trakx.CryptoCompare.ApiClient.Websocket.Model;
 
 public class Ticker : InboundMessageBase
 {
-#nullable disable
-    [JsonPropertyName("MARKET")] public string Market { get; set; }
-    [JsonPropertyName("FROMSYMBOL")] public string BaseSymbol { get; set; }
-    [JsonPropertyName("TOSYMBOL")] public string QuoteSymbol { get; set; }
+    [JsonPropertyName("MARKET")] public string? Market { get; set; }
+    [JsonPropertyName("FROMSYMBOL")] public string? BaseSymbol { get; set; }
+    [JsonPropertyName("TOSYMBOL")] public string? QuoteSymbol { get; set; }
 
     [JsonPropertyName("FLAGS"), JsonConverter(typeof(ULongOrStringConverter))]
     public ulong Flags { get; set; }
@@ -33,5 +32,4 @@ public class Ticker : InboundMessageBase
     [JsonPropertyName("OPENHOUR")] public decimal? OpenHour { get; set; }
     [JsonPropertyName("HIGHHOUR")] public decimal? HighHour { get; set; }
     [JsonPropertyName("LOWHOUR")] public decimal? LowHour { get; set; }
-#nullable restore
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/TopTierFullVolume.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/TopTierFullVolume.cs
@@ -4,8 +4,9 @@ namespace Trakx.CryptoCompare.ApiClient.Websocket.Model;
 
 public class TopTierFullVolume : InboundMessageBase
 {
-#nullable disable
-    [JsonPropertyName("SYMBOL")] public string Symbol { get; set; }
-    [JsonPropertyName("TOPTIERFULLVOLUME")] public string Volume { get; set; }
-#nullable restore
+    [JsonPropertyName("SYMBOL")]
+    public string Symbol { get; set; } = default!;
+
+    [JsonPropertyName("TOPTIERFULLVOLUME")]
+    public decimal Volume { get; set; }
 }

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/Trade.cs
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Model/Trade.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json.Serialization;
-using Trakx.Common.Serialization.Converters;
+using Trakx.Common.Serialization.Comparers;
 
 namespace Trakx.CryptoCompare.ApiClient.Websocket.Model;
 

--- a/src/Trakx.CryptoCompare.ApiClient.Websocket/Trakx.CryptoCompare.ApiClient.Websocket.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient.Websocket/Trakx.CryptoCompare.ApiClient.Websocket.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
 
-	<Import Project="../Common.Projects.props" />
-	<Import Project="../Packable.Projects.props" />
+  <Import Project="../Common.Projects.props" />
+  <Import Project="../Packable.Projects.props" />
 
-	<ItemGroup>
-		<PackageReference Include="Trakx.Common" Version="0.2.2" />
-		<PackageReference Include="Trakx.Websocket" Version="1.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Trakx.Common" Version="0.5.1" />
+    <PackageReference Include="Trakx.Common.Configuration" Version="0.5.1" />
+    <PackageReference Include="Trakx.Websocket" Version="1.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\Trakx.CryptoCompare.ApiClient\Trakx.CryptoCompare.ApiClient.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Trakx.CryptoCompare.ApiClient\Trakx.CryptoCompare.ApiClient.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/BaseApiClient.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/BaseApiClient.cs
@@ -63,18 +63,17 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             {
                 var apiResponseObject = JsonConvert.DeserializeObject<TApiResponse>(jsonResponse);
 
-                var baseApiResponse = apiResponseObject as BaseApiResponse;
-                if (baseApiResponse != null && !baseApiResponse.IsSuccessfulResponse)
+                if (apiResponseObject is BaseApiResponse baseApiResponse && !baseApiResponse.IsSuccessfulResponse)
                 {
                     throw new CryptoCompareException(baseApiResponse);
                 }
 
-                return apiResponseObject;
+                return apiResponseObject!;
             }
             catch (JsonSerializationException jsonSerializationException)
             {
                 var apiErrorResponse = JsonConvert.DeserializeObject<BaseApiResponse>(jsonResponse);
-                throw new CryptoCompareException(apiErrorResponse, jsonSerializationException);
+                throw new CryptoCompareException(apiErrorResponse!, jsonSerializationException);
             }
         }
     }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/HistoryClient.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/HistoryClient.cs
@@ -16,7 +16,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
         {
             Check.NotNull(httpClient, nameof(httpClient));
         }
-        
+
         /// <summary>
         /// Get the price of any cryptocurrency in any other currency that you need at a given timestamp.
         /// The price comes from the daily info - so it would be the price at the end of the day GMT based on the requested TS.
@@ -42,7 +42,6 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
         {
             Check.NotNullOrWhiteSpace(fromSymbol, nameof(fromSymbol));
             Check.NotEmpty(toSymbols, nameof(toSymbols));
-            
 
             return await this.GetAsync<PriceHistoricalReponse>(
                        ApiUrls.PriceHistorical(
@@ -53,7 +52,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
                            calculationType,
                            tryConversion)).ConfigureAwait(false);
         }
-  
+
         /// <summary>
         /// Get open, high, low, close, volumefrom and volumeto from the daily historical data.
         /// The values are based on 00:00 GMT time.It uses BTC conversion if data is not available because the coin is not trading in the specified currency.
@@ -69,7 +68,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
         public async Task<HistoryResponse> DailyAsync(
             string fromSymbol,
             string toSymbol,
-            int? limit = null,
+            int? limit,
             string? exchangeName = null,
             DateTimeOffset? toDate = null,
             bool? allData = null,

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/IHistoryClient.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/IHistoryClient.cs
@@ -26,7 +26,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             string fromSymbol,
             IEnumerable<string> toSymbols,
             DateTimeOffset requestedDate,
-            IEnumerable<string> markets = null,
+            IEnumerable<string>? markets = null,
             CalculationType? calculationType = null,
             bool? tryConversion = null);
 
@@ -46,7 +46,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             [NotNull] string fromSymbol,
             [NotNull] string toSymbol,
             int? limit,
-            string exchangeName = null,
+            string? exchangeName = null,
             DateTimeOffset? toDate = null,
             bool? allData = null,
             int? aggregate = null,
@@ -68,7 +68,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             [NotNull] string fromSymbol,
             [NotNull] string toSymbol,
             int? limit = null,
-            string exchangeName = null,
+            string? exchangeName = null,
             DateTimeOffset? toDate = null,
             bool? allData = null,
             int? aggregate = null,
@@ -91,7 +91,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             [NotNull] string fromSymbol,
             [NotNull] string toSymbol,
             int? limit = null,
-            string exchangeName = null,
+            string? exchangeName = null,
             DateTimeOffset? toDate = null,
             bool? allData = null,
             int? aggregate = null,
@@ -114,7 +114,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
         Task<HistoryDayAverageResponse> DayAveragePriceAsync(
             [NotNull] string fromSymbol,
             [NotNull] string toSymbol,
-            string exchangeName = null,
+            string? exchangeName = null,
             DateTimeOffset? toDate = null,
             CalculationType? avgType = null,
             int? utcHourDiff = null,
@@ -134,7 +134,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
         /// </returns>
         Task<ExchangeHistoryResponse> ExchangeDailyAsync(
             [NotNull] string toSymbol,
-            string exchangeName = null,
+            string? exchangeName = null,
             DateTimeOffset? toDate = null,
             int? limit = null,
             int? aggregate = null,
@@ -154,7 +154,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
         /// </returns>
         Task<ExchangeHistoryResponse> ExchangeHourlyAsync(
             [NotNull] string toSymbol,
-            string exchangeName = null,
+            string? exchangeName = null,
             DateTimeOffset? toDate = null,
             int? limit = null,
             int? aggregate = null,

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/INewsClient.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/INewsClient.cs
@@ -6,11 +6,11 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
 {
     public interface INewsClient
     {
-		/// <summary>
-		/// Return all news providers.
-		/// </summary>
-		/// <returns></returns>
-	    Task<IEnumerable<NewsProvider>> NewsProviders();
+        /// <summary>
+        /// Return all news providers.
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<NewsProvider>> NewsProviders();
         /// <summary>
         /// Get all news 
         /// </summary>
@@ -19,7 +19,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
         /// <param name="feeds">Feeds - for news</param>
         /// <param name="sign">if true cryptocompare will sign request</param>
         /// <returns></returns>
-        Task<IEnumerable<NewsEntity>> News(string lang = null, long? lTs = null, string[] feeds = null,
+        Task<IEnumerable<NewsEntity>> News(string? lang = null, long? lTs = null, string[]? feeds = null,
             bool? sign = null);
 
     }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/IPricesClient.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/IPricesClient.cs
@@ -32,7 +32,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             IEnumerable<string> fromSymbols,
             IEnumerable<string> toSymbols,
             bool? tryConversion = null,
-            string exchangeName = null);
+            string? exchangeName = null);
 
         /// <summary>
         /// Get all the current trading info (price, vol, open, high, low etc) of any list of cryptocurrencies in any other currency that you need.
@@ -49,7 +49,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             IEnumerable<string> fromSymbols,
             IEnumerable<string> toSymbols,
             bool? tryConversion = null,
-            string exchangeName = null);
+            string? exchangeName = null);
 
         /// <summary>
         /// Get the current price of any cryptocurrency in any other currency that you need.
@@ -64,6 +64,6 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             string fromSymbol,
             IEnumerable<string> toSymbols,
             bool? tryConversion = null,
-            string exchangeName = null);
+            string? exchangeName = null);
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/PriceClient.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Clients/PriceClient.cs
@@ -150,7 +150,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Clients
             [NotNull] string fromSymbol,
             [NotNull] IEnumerable<string> toSymbols,
             bool? tryConversion = null,
-            string exchangeName = null)
+            string? exchangeName = null)
         {
             Check.NotNull(fromSymbol, nameof(fromSymbol));
             Check.NotEmpty(toSymbols, nameof(toSymbols));

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Converters/StringToSubConverter.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Converters/StringToSubConverter.cs
@@ -37,12 +37,12 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Converters
         public override object ReadJson(
             JsonReader reader,
             Type objectType,
-            object existingValue,
+            object? existingValue,
             JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.String)
             {
-                return this.GetTokenFromString(reader.Value.ToString());
+                return GetTokenFromString(reader.Value?.ToString());
             }
 
             if (reader.TokenType == JsonToken.StartArray)
@@ -50,11 +50,11 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Converters
                 var tokens = JArray.Load(reader);
                 if (tokens?.HasValues ?? false)
                 {
-                    return tokens.Values().Select(token => this.GetTokenFromString(token.ToString())).ToList();
+                    return tokens.Values().Select(token => GetTokenFromString(token.ToString())).ToList();
                 }
             }
 
-            return null;
+            return null!;
         }
 
         /// <summary>
@@ -64,13 +64,14 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Converters
         /// <param name="value">The value.</param>
         /// <param name="serializer">The calling serializer.</param>
         /// <seealso cref="M:Newtonsoft.Json.JsonConverter.WriteJson(JsonWriter,object,JsonSerializer)"/>
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }
 
-        private Sub GetTokenFromString(string token)
+        private static Sub GetTokenFromString(string? token)
         {
+            if (token == null) return default;
             var values = token.Split('~');
             if (values.Length == 4)
             {
@@ -81,7 +82,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Converters
                     subId,
                     values.ElementAtOrDefault(3));
             }
-            return default(Sub);
+            return default;
         }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Core/ApiUrls.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Core/ApiUrls.cs
@@ -12,22 +12,22 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Core
     {
         private const string RateLimitsUrl = "/stats/rate/{0}/limit";
 
-        public static readonly Uri MinApiEndpoint = new Uri(
+        public static readonly Uri MinApiEndpoint = new(
             "https://min-api.cryptocompare.com/data/",
             UriKind.Absolute);
 
-        public static readonly Uri SiteApiEndpoint = new Uri(
+        public static readonly Uri SiteApiEndpoint = new(
             "https://www.cryptocompare.com/api/data/",
             UriKind.Absolute);
 
-        public static Uri AllCoins() => new Uri(MinApiEndpoint, "all/coinlist");
+        public static Uri AllCoins() => new(MinApiEndpoint, "all/coinlist");
 
-        public static Uri AllExchanges() => new Uri(MinApiEndpoint, "all/exchanges");
+        public static Uri AllExchanges() => new(MinApiEndpoint, "all/exchanges");
 
         public static Uri DayAveragePrice(
             string fsym,
             string tsym,
-            string e,
+            string? e,
             DateTimeOffset? toTs,
             CalculationType? avgType,
             int? UTCHourDiff,
@@ -97,9 +97,9 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Core
                 });
         }
 
-        public static Uri MiningContracts() => new Uri(SiteApiEndpoint, "miningcontracts");
+        public static Uri MiningContracts() => new(SiteApiEndpoint, "miningcontracts");
 
-        public static Uri MiningEquipments() => new Uri(SiteApiEndpoint, "miningequipment");
+        public static Uri MiningEquipments() => new(SiteApiEndpoint, "miningequipment");
 
         public static Uri News(string? lang = null, long? lTs = null, string[]? feeds = null, bool? sign = null)
         {
@@ -141,7 +141,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Core
         public static Uri PriceHistorical(
             string fsym,
             IEnumerable<string> tsyms,
-            IEnumerable<string> markets,
+            IEnumerable<string>? markets,
             DateTimeOffset ts,
             CalculationType? calculationType,
             bool? tryConversion)
@@ -215,11 +215,11 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Core
                 });
         }
 
-        public static Uri RateLimitsByHour() => new Uri(MinApiEndpoint, string.Format(RateLimitsUrl, "hour"));
+        public static Uri RateLimitsByHour() => new(MinApiEndpoint, string.Format(RateLimitsUrl, "hour"));
 
-        public static Uri RateLimitsByMinute() => new Uri(MinApiEndpoint, string.Format(RateLimitsUrl, "minute"));
+        public static Uri RateLimitsByMinute() => new(MinApiEndpoint, string.Format(RateLimitsUrl, "minute"));
 
-        public static Uri RateLimitsBySecond() => new Uri(MinApiEndpoint, string.Format(RateLimitsUrl, "second"));
+        public static Uri RateLimitsBySecond() => new(MinApiEndpoint, string.Format(RateLimitsUrl, "second"));
 
         public static Uri SocialStats([NotNull] int id)
         {

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Core/ThottledHttpClientHandler.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Core/ThottledHttpClientHandler.cs
@@ -24,14 +24,14 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Core
             this._semaphore = new SemaphoreSlim(1, 1);
         }
 
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            Check.NotNull(requestMessage, nameof(requestMessage));
+            Check.NotNull(request, nameof(request));
 
             await this._semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                return await base.SendAsync(requestMessage, cancellationToken);
+                return await base.SendAsync(request, cancellationToken);
             }
             finally
             {

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Extensions/DateTimeExtensions.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Extensions/DateTimeExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using Trakx.Common.Extensions;
 
 namespace Trakx.CryptoCompare.ApiClient.Rest.Extensions
 {
     public static class DateTimeExtensions
     {
-        private static readonly DateTimeOffset epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        private static readonly DateTimeOffset epoch = (1970, 1, 1).ToDateTimeOffset();
 
         /// <summary>
         /// Convert a Unix tick to a <see cref="DateTimeOffset"/> with UTC offset

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Extensions/UriExtensions.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Extensions/UriExtensions.cs
@@ -33,7 +33,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Extensions
             var hasQueryString = uri.OriginalString.IndexOf("?", StringComparison.Ordinal);
 
             var uriWithoutQuery =
-                hasQueryString == -1 ? uri.ToString() : uri.OriginalString.Substring(0, hasQueryString);
+                hasQueryString == -1 ? uri.ToString() : uri.OriginalString[..hasQueryString];
 
             string queryString;
             if (uri.IsAbsoluteUri)
@@ -42,33 +42,33 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Extensions
             }
             else
             {
-                queryString = hasQueryString == -1 ? "" : uri.OriginalString.Substring(hasQueryString);
+                queryString = hasQueryString == -1 ? "" : uri.OriginalString[hasQueryString..];
             }
 
             var values = queryString.Replace("?", "").Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
 
             var existingParameters = values.ToDictionary(
-                key => key.Substring(0, key.IndexOf('=')),
-                value => value.Substring(value.IndexOf('=') + 1));
+                key => key[..key.IndexOf('=')],
+                value => value[(value.IndexOf('=') + 1)..]);
 
             foreach (var (k, v) in existingParameters)
             {
                 if (!p.ContainsKey(k))
                 {
-                    p.Add(k,v);
+                    p.Add(k, v);
                 }
             }
 
             var query = string.Join(
                 "&",
                 p.Where(param => !string.IsNullOrWhiteSpace(param.Value))
-                    .Select(kvp => kvp.Key + "=" + Uri.EscapeDataString(kvp.Value)));
+                    .Select(kvp => kvp.Key + "=" + Uri.EscapeDataString(kvp.Value!)));
             if (uri.IsAbsoluteUri)
             {
                 var uriBuilder = new UriBuilder(uri)
-                                 {
-                                     Query = query
-                                 };
+                {
+                    Query = query
+                };
                 return uriBuilder.Uri;
             }
 

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Helpers/Check.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Helpers/Check.cs
@@ -23,7 +23,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Helpers
         [ContractAnnotation("value:null => halt")]
         public static IEnumerable<T> NotEmpty<T>(
             IEnumerable<T> value,
-            [InvokerParameterName] [NotNull] string parameterName)
+            [InvokerParameterName][NotNull] string parameterName)
         {
             NotNull(value, parameterName);
 
@@ -47,9 +47,9 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Helpers
         /// Checked object.
         /// </returns>
         [ContractAnnotation("value:null => halt")]
-        public static T NotNull<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
+        public static T NotNull<T>(T value, [InvokerParameterName][NotNull] string parameterName)
         {
-            if (ReferenceEquals(value, null))
+            if (value is null)
             {
                 NotNullOrWhiteSpace(parameterName, nameof(parameterName));
                 throw new ArgumentNullException(parameterName);
@@ -67,7 +67,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Helpers
         /// Checked object.
         /// </returns>
         [ContractAnnotation("value:null => halt")]
-        public static string NotNullOrWhiteSpace(string value, [InvokerParameterName] [NotNull] string parameterName)
+        public static string NotNullOrWhiteSpace(string? value, [InvokerParameterName][NotNull] string parameterName)
         {
             if (string.IsNullOrWhiteSpace(value))
             {

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Helpers/JetbrainsAnnotations.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Helpers/JetbrainsAnnotations.cs
@@ -22,7 +22,6 @@ SOFTWARE. */
 
 using System;
 
-#pragma warning disable 1591
 // ReSharper disable UnusedMember.Global
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -134,7 +133,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string FormatParameterName { get; private set; }
+        public string? FormatParameterName { get; private set; }
     }
 
     /// <summary>
@@ -150,7 +149,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Name { get; private set; }
+        public string? Name { get; private set; }
     }
 
     /// <summary>
@@ -220,7 +219,7 @@ namespace JetBrains.Annotations
         }
 
         [CanBeNull]
-        public string ParameterName { get; private set; }
+        public string? ParameterName { get; private set; }
     }
 
     /// <summary>
@@ -281,7 +280,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Contract { get; private set; }
+        public string? Contract { get; private set; }
 
         public bool ForceFullStates { get; private set; }
     }
@@ -368,29 +367,29 @@ namespace JetBrains.Annotations
     internal sealed class UsedImplicitlyAttribute : Attribute
     {
         public UsedImplicitlyAttribute()
-            : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default)
+            : this(ImplicitUseKind.Default, ImplicitUseTarget.Default)
         {
         }
 
-        public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags)
-            : this(useKindFlags, ImplicitUseTargetFlags.Default)
+        public UsedImplicitlyAttribute(ImplicitUseKind useKindFlags)
+            : this(useKindFlags, ImplicitUseTarget.Default)
         {
         }
 
-        public UsedImplicitlyAttribute(ImplicitUseTargetFlags targetFlags)
-            : this(ImplicitUseKindFlags.Default, targetFlags)
+        public UsedImplicitlyAttribute(ImplicitUseTarget targetFlags)
+            : this(ImplicitUseKind.Default, targetFlags)
         {
         }
 
-        public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+        public UsedImplicitlyAttribute(ImplicitUseKind useKindFlags, ImplicitUseTarget targetFlags)
         {
             UseKindFlags = useKindFlags;
             TargetFlags = targetFlags;
         }
 
-        public ImplicitUseTargetFlags TargetFlags { get; private set; }
+        public ImplicitUseTarget TargetFlags { get; private set; }
 
-        public ImplicitUseKindFlags UseKindFlags { get; private set; }
+        public ImplicitUseKind UseKindFlags { get; private set; }
     }
 
     /// <summary>
@@ -401,35 +400,35 @@ namespace JetBrains.Annotations
     internal sealed class MeansImplicitUseAttribute : Attribute
     {
         public MeansImplicitUseAttribute()
-            : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default)
+            : this(ImplicitUseKind.Default, ImplicitUseTarget.Default)
         {
         }
 
-        public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags)
-            : this(useKindFlags, ImplicitUseTargetFlags.Default)
+        public MeansImplicitUseAttribute(ImplicitUseKind useKindFlags)
+            : this(useKindFlags, ImplicitUseTarget.Default)
         {
         }
 
-        public MeansImplicitUseAttribute(ImplicitUseTargetFlags targetFlags)
-            : this(ImplicitUseKindFlags.Default, targetFlags)
+        public MeansImplicitUseAttribute(ImplicitUseTarget targetFlags)
+            : this(ImplicitUseKind.Default, targetFlags)
         {
         }
 
-        public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+        public MeansImplicitUseAttribute(ImplicitUseKind useKindFlags, ImplicitUseTarget targetFlags)
         {
             UseKindFlags = useKindFlags;
             TargetFlags = targetFlags;
         }
 
         [UsedImplicitly]
-        public ImplicitUseTargetFlags TargetFlags { get; private set; }
+        public ImplicitUseTarget TargetFlags { get; private set; }
 
         [UsedImplicitly]
-        public ImplicitUseKindFlags UseKindFlags { get; private set; }
+        public ImplicitUseKind UseKindFlags { get; private set; }
     }
 
     [Flags]
-    internal enum ImplicitUseKindFlags
+    internal enum ImplicitUseKind
     {
         Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
 
@@ -454,7 +453,7 @@ namespace JetBrains.Annotations
     /// with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>.
     /// </summary>
     [Flags]
-    internal enum ImplicitUseTargetFlags
+    internal enum ImplicitUseTarget
     {
         Default = Itself,
 
@@ -471,20 +470,20 @@ namespace JetBrains.Annotations
     /// This attribute is intended to mark publicly available API
     /// which should not be removed and so is treated as used.
     /// </summary>
-    [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
-    internal sealed class PublicAPIAttribute : Attribute
+    [MeansImplicitUse(ImplicitUseTarget.WithMembers)]
+    internal sealed class PublicApiAttribute : Attribute
     {
-        public PublicAPIAttribute()
+        public PublicApiAttribute()
         {
         }
 
-        public PublicAPIAttribute([NotNull] string comment)
+        public PublicApiAttribute([NotNull] string comment)
         {
             Comment = comment;
         }
 
         [CanBeNull]
-        public string Comment { get; private set; }
+        public string? Comment { get; private set; }
     }
 
     /// <summary>
@@ -529,7 +528,7 @@ namespace JetBrains.Annotations
         }
 
         [CanBeNull]
-        public string Justification { get; private set; }
+        public string? Justification { get; private set; }
     }
 
     /// <summary>
@@ -572,7 +571,7 @@ namespace JetBrains.Annotations
         }
 
         [CanBeNull]
-        public string BasePath { get; private set; }
+        public string? BasePath { get; private set; }
     }
 
     /// <summary>
@@ -648,13 +647,13 @@ namespace JetBrains.Annotations
         /// Allows specifying a macro that will be executed for a <see cref="SourceTemplateAttribute">source template</see>
         /// parameter when the template is expanded.
         /// </summary>
-        public string Expression { get; set; }
+        public string? Expression { get; set; }
 
         /// <summary>
         /// Identifies the target parameter of a <see cref="SourceTemplateAttribute">source template</see> if the
         /// <see cref="MacroAttribute"/> is applied on a template method.
         /// </summary>
-        public string Target { get; set; }
+        public string? Target { get; set; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -666,7 +665,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Format { get; private set; }
+        public string? Format { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -678,7 +677,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Format { get; private set; }
+        public string? Format { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -690,7 +689,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Format { get; private set; }
+        public string? Format { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -713,7 +712,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Format { get; private set; }
+        public string? Format { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -725,7 +724,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Format { get; private set; }
+        public string? Format { get; private set; }
     }
 
     /// <summary>
@@ -747,7 +746,7 @@ namespace JetBrains.Annotations
         }
 
         [CanBeNull]
-        public string AnonymousProperty { get; private set; }
+        public string? AnonymousProperty { get; private set; }
     }
 
     /// <summary>
@@ -768,7 +767,7 @@ namespace JetBrains.Annotations
         }
 
         [CanBeNull]
-        public string AnonymousProperty { get; private set; }
+        public string? AnonymousProperty { get; private set; }
     }
 
     /// <summary>
@@ -790,7 +789,7 @@ namespace JetBrains.Annotations
         }
 
         [CanBeNull]
-        public string AnonymousProperty { get; private set; }
+        public string? AnonymousProperty { get; private set; }
     }
 
     /// <summary>
@@ -918,7 +917,7 @@ namespace JetBrains.Annotations
         }
 
         [CanBeNull]
-        public string Name { get; private set; }
+        public string? Name { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property)]
@@ -930,7 +929,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Name { get; private set; }
+        public string? Name { get; private set; }
     }
 
     /// <summary>
@@ -1091,7 +1090,7 @@ namespace JetBrains.Annotations
         public Type ControlType { get; private set; }
 
         [NotNull]
-        public string TagName { get; private set; }
+        public string? TagName { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
@@ -1118,7 +1117,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Attribute { get; private set; }
+        public string? Attribute { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Property)]
@@ -1141,7 +1140,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Name { get; private set; }
+        public string? Name { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -1154,10 +1153,10 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string FieldName { get; private set; }
+        public string? FieldName { get; private set; }
 
         [NotNull]
-        public string Type { get; private set; }
+        public string? Type { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -1169,7 +1168,7 @@ namespace JetBrains.Annotations
         }
 
         [NotNull]
-        public string Directive { get; private set; }
+        public string? Directive { get; private set; }
     }
 
     [AttributeUsage(AttributeTargets.Method)]
@@ -1204,7 +1203,7 @@ namespace JetBrains.Annotations
     /// The attribute must be mentioned in your member reordering patterns
     /// </remarks>
     [AttributeUsage(AttributeTargets.All)]
-    internal sealed class NoReorder : Attribute
+    internal sealed class NoReorderAttribute : Attribute
     {
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Helpers/JetbrainsAnnotations.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Helpers/JetbrainsAnnotations.cs
@@ -367,29 +367,29 @@ namespace JetBrains.Annotations
     internal sealed class UsedImplicitlyAttribute : Attribute
     {
         public UsedImplicitlyAttribute()
-            : this(ImplicitUseKind.Default, ImplicitUseTarget.Default)
+            : this(ImplicitUseKinds.Default, ImplicitUseTargets.Default)
         {
         }
 
-        public UsedImplicitlyAttribute(ImplicitUseKind useKindFlags)
-            : this(useKindFlags, ImplicitUseTarget.Default)
+        public UsedImplicitlyAttribute(ImplicitUseKinds useKindFlags)
+            : this(useKindFlags, ImplicitUseTargets.Default)
         {
         }
 
-        public UsedImplicitlyAttribute(ImplicitUseTarget targetFlags)
-            : this(ImplicitUseKind.Default, targetFlags)
+        public UsedImplicitlyAttribute(ImplicitUseTargets targetFlags)
+            : this(ImplicitUseKinds.Default, targetFlags)
         {
         }
 
-        public UsedImplicitlyAttribute(ImplicitUseKind useKindFlags, ImplicitUseTarget targetFlags)
+        public UsedImplicitlyAttribute(ImplicitUseKinds useKindFlags, ImplicitUseTargets targetFlags)
         {
             UseKindFlags = useKindFlags;
             TargetFlags = targetFlags;
         }
 
-        public ImplicitUseTarget TargetFlags { get; private set; }
+        public ImplicitUseTargets TargetFlags { get; private set; }
 
-        public ImplicitUseKind UseKindFlags { get; private set; }
+        public ImplicitUseKinds UseKindFlags { get; private set; }
     }
 
     /// <summary>
@@ -400,35 +400,35 @@ namespace JetBrains.Annotations
     internal sealed class MeansImplicitUseAttribute : Attribute
     {
         public MeansImplicitUseAttribute()
-            : this(ImplicitUseKind.Default, ImplicitUseTarget.Default)
+            : this(ImplicitUseKinds.Default, ImplicitUseTargets.Default)
         {
         }
 
-        public MeansImplicitUseAttribute(ImplicitUseKind useKindFlags)
-            : this(useKindFlags, ImplicitUseTarget.Default)
+        public MeansImplicitUseAttribute(ImplicitUseKinds useKindFlags)
+            : this(useKindFlags, ImplicitUseTargets.Default)
         {
         }
 
-        public MeansImplicitUseAttribute(ImplicitUseTarget targetFlags)
-            : this(ImplicitUseKind.Default, targetFlags)
+        public MeansImplicitUseAttribute(ImplicitUseTargets targetFlags)
+            : this(ImplicitUseKinds.Default, targetFlags)
         {
         }
 
-        public MeansImplicitUseAttribute(ImplicitUseKind useKindFlags, ImplicitUseTarget targetFlags)
+        public MeansImplicitUseAttribute(ImplicitUseKinds useKindFlags, ImplicitUseTargets targetFlags)
         {
             UseKindFlags = useKindFlags;
             TargetFlags = targetFlags;
         }
 
         [UsedImplicitly]
-        public ImplicitUseTarget TargetFlags { get; private set; }
+        public ImplicitUseTargets TargetFlags { get; private set; }
 
         [UsedImplicitly]
-        public ImplicitUseKind UseKindFlags { get; private set; }
+        public ImplicitUseKinds UseKindFlags { get; private set; }
     }
 
     [Flags]
-    internal enum ImplicitUseKind
+    internal enum ImplicitUseKinds
     {
         Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
 
@@ -453,7 +453,7 @@ namespace JetBrains.Annotations
     /// with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>.
     /// </summary>
     [Flags]
-    internal enum ImplicitUseTarget
+    internal enum ImplicitUseTargets
     {
         Default = Itself,
 
@@ -470,7 +470,7 @@ namespace JetBrains.Annotations
     /// This attribute is intended to mark publicly available API
     /// which should not be removed and so is treated as used.
     /// </summary>
-    [MeansImplicitUse(ImplicitUseTarget.WithMembers)]
+    [MeansImplicitUse(ImplicitUseTargets.WithMembers)]
     internal sealed class PublicApiAttribute : Attribute
     {
         public PublicApiAttribute()

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/AggregatedData.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/AggregatedData.cs
@@ -7,16 +7,16 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
     public class AggregatedData
     {
         [JsonProperty("FLAGS")]
-        public string Flags { get; set; }
+        public string? Flags { get; set; }
 
         [JsonProperty("FROMSYMBOL")]
-        public string BaseSymbol { get; set; }
+        public string? BaseSymbol { get; set; }
 
         [JsonProperty("HIGH24HOUR")]
         public double? High24Hour { get; set; }
 
         [JsonProperty("LASTTRADEID")]
-        public string LastTradeId { get; set; }
+        public string? LastTradeId { get; set; }
 
         [JsonConverter(typeof(UnixTimeConverter))]
         [JsonProperty("LASTUPDATE")]
@@ -32,7 +32,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
         public double? Low24Hour { get; set; }
 
         [JsonProperty("MARKET")]
-        public string Market { get; set; }
+        public string? Market { get; set; }
 
         [JsonProperty("OPEN24HOUR")]
         public double? Open24Hour { get; set; }
@@ -41,10 +41,10 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
         public double? Price { get; set; }
 
         [JsonProperty("TOSYMBOL")]
-        public string QuoteSymbol { get; set; }
+        public string? QuoteSymbol { get; set; }
 
         [JsonProperty("TYPE")]
-        public string Type { get; set; }
+        public string? Type { get; set; }
 
         [JsonProperty("VOLUME24HOUR")]
         public double? Volume24Hour { get; set; }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/Calls.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/Calls.cs
@@ -1,10 +1,9 @@
-﻿#pragma warning disable 8618
-namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
+﻿namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
     /// <summary>
     /// Api calls.
     /// </summary>
-public class Calls
+    public class Calls
     {
         /// <summary>
         /// Calls to history apis.

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinAggregatedData.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinAggregatedData.cs
@@ -8,7 +8,7 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
         public double? HighDay { get; set; }
 
         [JsonProperty("LASTMARKET")]
-        public string LastMarket { get; set; }
+        public string? LastMarket { get; set; }
 
         [JsonProperty("LOWDAY")]
         public double? LowDay { get; set; }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinSnapshotFullData.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinSnapshotFullData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using Newtonsoft.Json;
 using Trakx.CryptoCompare.ApiClient.Rest.Converters;
 
@@ -6,15 +7,15 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
     public class CoinSnapshotFullData
     {
-        public CoinGeneralInfo General { get; set; }
+        public CoinGeneralInfo? General { get; set; }
 
-        public ICO ICO { get; set; }
+        public ICO? ICO { get; set; }
 
-        public SEO SEO { get; set; }
+        public SEO? SEO { get; set; }
 
-        public IReadOnlyList<string> StreamerDataRaw { get; set; }
+        public IReadOnlyList<string> StreamerDataRaw { get; set; } = ImmutableList<string>.Empty;
 
         [JsonConverter(typeof(StringToSubConverter))]
-        public IReadOnlyList<Sub> Subs { get; set; }
+        public IReadOnlyList<Sub> Subs { get; set; } = ImmutableList<Sub>.Empty;
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinSnapshotFullData.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinSnapshotFullData.cs
@@ -9,9 +9,9 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
     {
         public CoinGeneralInfo? General { get; set; }
 
-        public ICO? ICO { get; set; }
+        public Ico? ICO { get; set; }
 
-        public SEO? SEO { get; set; }
+        public Seo? SEO { get; set; }
 
         public IReadOnlyList<string> StreamerDataRaw { get; set; } = ImmutableList<string>.Empty;
 

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinSnapshotFullResponse.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/CoinSnapshotFullResponse.cs
@@ -2,6 +2,6 @@
 {
     public class CoinSnapshotFullResponse : BaseApiResponse
     {
-        public CoinSnapshotFullData Data { get; set; }
+        public CoinSnapshotFullData? Data { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/ICO.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/ICO.cs
@@ -5,7 +5,7 @@ using Trakx.CryptoCompare.ApiClient.Rest.Converters;
 
 namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
-    public class ICO
+    public class Ico
     {
         public string Blog { get; set; }
 

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/MarketCapDisplay.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/MarketCapDisplay.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-#pragma warning disable 8618
 
 namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/MiningEquipment.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/MiningEquipment.cs
@@ -2,8 +2,8 @@
 {
     public class MiningEquipment : MiningData
     {
-        public string EquipmentType { get; set; }
+        public string? EquipmentType { get; set; }
 
-        public string PowerConsumption { get; set; }
+        public string? PowerConsumption { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/MiningEquipmentsResponse.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/MiningEquipmentsResponse.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
     public class MiningEquipmentsResponse : BaseApiResponse
     {
-        public IReadOnlyDictionary<string, MiningEquipment> MiningData { get; set; }
+        public IReadOnlyDictionary<string, MiningEquipment> MiningData { get; set; } = ImmutableDictionary<string, MiningEquipment>.Empty;
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/PriceAverageResponse.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/PriceAverageResponse.cs
@@ -5,9 +5,9 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
     public class PriceAverageResponse
     {
         [JsonProperty("DISPLAY")]
-        public CoinFullAggregatedDataDisplay Display { get; set; }
+        public CoinFullAggregatedDataDisplay? Display { get; set; }
 
         [JsonProperty("RAW")]
-        public CoinFullAggregatedData Raw { get; set; }
+        public CoinFullAggregatedData? Raw { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/PriceMultiFullResponse.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/PriceMultiFullResponse.cs
@@ -5,9 +5,9 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
     public class PriceMultiFullResponse
     {
         [JsonProperty("DISPLAY")]
-        public PriceMultiFullDisplay Display { get; set; }
+        public PriceMultiFullDisplay? Display { get; set; }
 
         [JsonProperty("RAW")]
-        public PriceMultiFullRaw Raw { get; set; }
+        public PriceMultiFullRaw? Raw { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/SEO.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/SEO.cs
@@ -1,6 +1,6 @@
 ﻿namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
-    public class SEO
+    public class Seo
     {
         public string? BaseImageUrl { get; set; }
 

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/SEO.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/SEO.cs
@@ -2,18 +2,18 @@
 {
     public class SEO
     {
-        public string BaseImageUrl { get; set; }
+        public string? BaseImageUrl { get; set; }
 
-        public string BaseUrl { get; set; }
+        public string? BaseUrl { get; set; }
 
         public int OgImageHeight { get; set; }
 
-        public string OgImageUrl { get; set; }
+        public string? OgImageUrl { get; set; }
 
         public int OgImageWidth { get; set; }
 
-        public string PageDescription { get; set; }
+        public string? PageDescription { get; set; }
 
-        public string PageTitle { get; set; }
+        public string? PageTitle { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/Sub.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/Sub.cs
@@ -1,19 +1,19 @@
 ﻿using System;
-using JetBrains.Annotations;
 using Trakx.CryptoCompare.ApiClient.Rest.Helpers;
 
 namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
     public readonly struct Sub : IEquatable<Sub>
     {
-        public bool Equals(Sub other) => string.Equals(this.Exchange, other.Exchange)
-                                            && string.Equals(this.BaseSymbol, other.BaseSymbol)
-                                            && this.SubId == other.SubId
-                                            && string.Equals(this.QuoteSymbol, other.QuoteSymbol);
+        public bool Equals(Sub other)
+            => string.Equals(this.Exchange, other.Exchange)
+            && string.Equals(this.BaseSymbol, other.BaseSymbol)
+            && this.SubId == other.SubId
+            && string.Equals(this.QuoteSymbol, other.QuoteSymbol);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }
@@ -22,25 +22,18 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                var hashCode = this.Exchange.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.BaseSymbol.GetHashCode();
-                hashCode = (hashCode * 397) ^ (int)this.SubId;
-                hashCode = (hashCode * 397) ^ this.QuoteSymbol.GetHashCode();
-                return hashCode;
-            }
+            return HashCode.Combine(Exchange, BaseSymbol, SubId, QuoteSymbol);
         }
 
-        public Sub([NotNull] string exchange, [NotNull] string fromSymbol, SubId subId, [NotNull] string toSymbol)
+        public Sub(string? exchange, string? fromSymbol, SubId subId, string? toSymbol)
         {
             Check.NotNullOrWhiteSpace(exchange, nameof(exchange));
             Check.NotNullOrWhiteSpace(fromSymbol, nameof(fromSymbol));
             Check.NotNullOrWhiteSpace(toSymbol, nameof(toSymbol));
-            this.Exchange = exchange;
-            this.BaseSymbol = fromSymbol;
+            this.Exchange = exchange!;
+            this.BaseSymbol = fromSymbol!;
             this.SubId = subId;
-            this.QuoteSymbol = toSymbol;
+            this.QuoteSymbol = toSymbol!;
         }
 
         public string Exchange { get; }
@@ -54,6 +47,16 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
         public override string ToString()
         {
             return $"{this.SubId:D}~{this.Exchange}~{this.BaseSymbol}~{this.QuoteSymbol}";
+        }
+
+        public static bool operator ==(Sub left, Sub right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Sub left, Sub right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/SubListResponse.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/SubListResponse.cs
@@ -16,12 +16,12 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
     public class SubList
     {
         [JsonConverter(typeof(StringToSubConverter))]
-        public IReadOnlyList<Sub> Current { get; set; }
+        public IReadOnlyList<Sub>? Current { get; set; }
 
         [JsonConverter(typeof(StringToSubConverter))]
-        public Sub CurrentAgg { get; set; }
+        public Sub? CurrentAgg { get; set; }
 
         [JsonConverter(typeof(StringToSubConverter))]
-        public IReadOnlyList<Sub> Trades { get; set; }
+        public IReadOnlyList<Sub>? Trades { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/TopVolume24HInfo.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/TopVolume24HInfo.cs
@@ -4,12 +4,12 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
     public class TopVolume24HInfo
     {
-        public CoinInfo CoinInfo { get; set; }
+        public CoinInfo? CoinInfo { get; set; }
 
         [JsonProperty("DISPLAY")]
-        public Volume24HDisplay Display { get; set; }
+        public Volume24HDisplay? Display { get; set; }
 
         [JsonProperty("RAW")]
-        public Volume24HRaw Raw { get; set; }
+        public Volume24HRaw? Raw { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/TopVolume24HResponse.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/TopVolume24HResponse.cs
@@ -4,6 +4,6 @@ namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
     public class TopVolume24HResponse : BaseApiResponse
     {
-        public IReadOnlyList<TopVolume24HInfo> Data { get; set; }
+        public IReadOnlyList<TopVolume24HInfo>? Data { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/TopVolumesResponse.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/Rest/Models/Responses/TopVolumesResponse.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Trakx.CryptoCompare.ApiClient.Rest.Models.Responses
 {
     public class TopVolumesResponse : BaseApiResponse
     {
-        public IReadOnlyList<TopVolumeInfo> Data { get; set; }
+        public IReadOnlyList<TopVolumeInfo> Data { get; set; } = ImmutableList<TopVolumeInfo>.Empty;
 
-        public string VolSymbol { get; set; }
+        public string? VolSymbol { get; set; }
     }
 }

--- a/src/Trakx.CryptoCompare.ApiClient/ServiceConfiguration.cs
+++ b/src/Trakx.CryptoCompare.ApiClient/ServiceConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Trakx.Common.Configuration;
 using Trakx.CryptoCompare.ApiClient.Rest;
 
 namespace Trakx.CryptoCompare.ApiClient
@@ -16,8 +17,7 @@ namespace Trakx.CryptoCompare.ApiClient
 
         public static IServiceCollection AddCryptoCompareClient(this IServiceCollection services, IConfiguration configuration)
         {
-            var apiConfiguration = configuration.GetSection(nameof(CryptoCompareApiConfiguration))
-                .Get<CryptoCompareApiConfiguration>();
+            var apiConfiguration = configuration.GetConfiguration<CryptoCompareApiConfiguration>();
             return AddCryptoCompareClient(services, apiConfiguration);
         }
     }

--- a/src/Trakx.CryptoCompare.ApiClient/Trakx.CryptoCompare.ApiClient.csproj
+++ b/src/Trakx.CryptoCompare.ApiClient/Trakx.CryptoCompare.ApiClient.csproj
@@ -10,8 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="Trakx.Common" Version="0.2.2" />
+    <PackageReference Include="Polly" Version="8.0.0" />
+    <PackageReference Include="Trakx.Common" Version="0.5.1" />
+    <PackageReference Include="Trakx.Common.Configuration" Version="0.5.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Nuget bumps
Fix IDE warnings and messages
Nullable properties

Fix issue found in `marketdata-collector`:

```
 at Trakx.CryptoCompare.ApiClient.Websocket.CryptoCompareWebsocketHandler.DeserializeClientSocketIncoming(String topic, IncomingMessage m)
   at System.Text.Json.JsonSerializer.Deserialize(String json, Type returnType, JsonSerializerOptions options)
   ...
System.TypeLoadException: Could not load type 'Trakx.Common.Serialization.Converters.ULongOrStringConverter' from assembly 'Trakx.Common, Version=0.2.2.0, Culture=neutral, PublicKeyToken=null'.

```